### PR TITLE
fix: correct Geist font imports

### DIFF
--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,9 +1,10 @@
 import type { AppProps } from 'next/app';
 import '../styles/globals.css';
-import { GeistSans as Geist, GeistMono as Geist_Mono } from 'geist/font';
 import '@rainbow-me/rainbowkit/styles.css';
 import { getDefaultConfig, RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import { WagmiProvider } from 'wagmi';
+import { GeistSans as Geist } from 'geist/font/sans';
+import { GeistMono as Geist_Mono } from 'geist/font/mono';
 
 export default function App({ Component, pageProps }: AppProps) {
   return (


### PR DESCRIPTION
## Summary
- replace incorrect Geist font imports with `geist/font/sans` and `geist/font/mono`
- install Geist font package

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68a88ede4c5c833185b56f0598f97479