### PR TITLE
Replace Geist with Google Fonts for Next.js build

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,6 @@
         "@rainbow-me/rainbowkit": "^2.1.2",
         "@tanstack/react-query": "^5.51.15",
         "framer-motion": "^12.23.12",
-        "geist": "^1.4.2",
         "next": "15.4.5",
         "react": "19.1.0",
         "react-dom": "19.1.0",
@@ -6495,15 +6494,6 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/geist": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/geist/-/geist-1.4.2.tgz",
-      "integrity": "sha512-OQUga/KUc8ueijck6EbtT07L4tZ5+TZgjw8PyWfxo16sL5FWk7gNViPNU8hgCFjy6bJi9yuTP+CRpywzaGN8zw==",
-      "license": "SIL OPEN FONT LICENSE",
-      "peerDependencies": {
-        "next": ">=13.2.0"
       }
     },
     "node_modules/get-caller-file": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,6 @@
     "@rainbow-me/rainbowkit": "^2.1.2",
     "@tanstack/react-query": "^5.51.15",
     "framer-motion": "^12.23.12",
-    "geist": "^1.4.2",
     "next": "15.4.5",
     "react": "19.1.0",
     "react-dom": "19.1.0",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -3,8 +3,9 @@ import '../styles/globals.css';
 import '@rainbow-me/rainbowkit/styles.css';
 import { getDefaultConfig, RainbowKitProvider } from '@rainbow-me/rainbowkit';
 import { WagmiProvider } from 'wagmi';
-import { GeistSans as Geist } from 'geist/font/sans';
-import { GeistMono as Geist_Mono } from 'geist/font/mono';
+import { Inter, Roboto_Mono } from 'next/font/google';
+const Geist = Inter({ subsets: ['latin'], variable: '--font-geist-sans' });
+const Geist_Mono = Roboto_Mono({ subsets: ['latin'], variable: '--font-geist-mono' });
 
 export default function App({ Component, pageProps }: AppProps) {
   return (

--- a/package.json
+++ b/package.json
@@ -13,31 +13,36 @@
     "test": "hardhat test"
   },
   "dependencies": {
+    "@rainbow-me/rainbowkit": "^2.0.0",
+    "@tanstack/react-query": "^5.0.0",
+    "framer-motion": "^10.0.0",
     "next": "^14.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
-    "framer-motion": "^10.0.0",
     "react-icons": "^4.0.0",
-    "wagmi": "^2.0.0",
-    "@rainbow-me/rainbowkit": "^2.0.0",
-    "@tanstack/react-query": "^5.0.0",
-    "viem": "^2.0.0"
+    "viem": "^2.0.0",
+    "wagmi": "^2.0.0"
   },
   "devDependencies": {
     "@nomicfoundation/hardhat-toolbox": "^4.0.0",
-    "hardhat-deploy": "^0.11.0",
-    "dotenv": "^16.0.0",
     "@types/node": "^20.0.0",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
-    "typescript": "^5.0.0",
-    "tailwindcss": "^3.0.0",
-    "postcss": "^8.0.0",
     "autoprefixer": "^10.0.0",
+    "dotenv": "^16.0.0",
     "eslint": "^8.0.0",
-    "eslint-config-next": "^14.0.0"
+    "eslint-config-next": "^14.0.0",
+    "hardhat-deploy": "^0.11.0",
+    "postcss": "^8.0.0",
+    "tailwindcss": "^3.0.0",
+    "typescript": "^5.0.0"
   },
-  "keywords": ["dao", "blockchain", "nextjs", "hardhat"],
+  "keywords": [
+    "dao",
+    "blockchain",
+    "nextjs",
+    "hardhat"
+  ],
   "author": "",
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- remove Geist dependency
- load Inter and Roboto_Mono from `next/font/google`

## Testing
- `npm install`
- `npm run build` *(fails: Failed to fetch Inter/Roboto Mono from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_b_68a891285d748331a2a1747379c9c558